### PR TITLE
Jruby error

### DIFF
--- a/lib/dynamo-local-ruby/dynamo_db_local.rb
+++ b/lib/dynamo-local-ruby/dynamo_db_local.rb
@@ -28,6 +28,7 @@ module DynamoLocalRuby
       end
     end
 
+    # rubocop:disable HandleExceptions
     def down
       return unless @pid
       begin
@@ -38,5 +39,6 @@ module DynamoLocalRuby
       end
       @pid = nil
     end
+    # rubocop:enable HandleExceptions
   end
 end

--- a/lib/dynamo-local-ruby/dynamo_db_local.rb
+++ b/lib/dynamo-local-ruby/dynamo_db_local.rb
@@ -30,8 +30,12 @@ module DynamoLocalRuby
 
     def down
       return unless @pid
-      Process.kill('SIGINT', @pid)
-      Process.waitpid2(@pid)
+      begin
+        Process.kill('SIGINT', @pid)
+        Process.waitpid2(@pid)
+      rescue Errno::ECHILD, Errno::ESRCH
+        # child process is dead
+      end
       @pid = nil
     end
   end


### PR DESCRIPTION
@peakxu 

JRuby tosses an `Errno::ECHILD` if the process dies before the `waitpid2` is called
