### PR TITLE
allow dynamo port to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 In your application code, initialize Dynamo clients with
 
-    Aws::DynamoDB::Client.new(endpoint: DynamoLocalRuby::DynamoDBLocal::ENDPOINT)
+    Aws::DynamoDB::Client.new(endpoint: DynamoLocalRuby::DynamoDBLocal.endpoint)
 
 Before the test suite starts (for instance in RSpec's `config.before(:suite)`).
 

--- a/lib/dynamo-local-ruby/dynamo_db_local.rb
+++ b/lib/dynamo-local-ruby/dynamo_db_local.rb
@@ -4,13 +4,16 @@ module DynamoLocalRuby
   # Wrapper around Dynamo DB local process
   class DynamoDBLocal
     PORT = 9389
-    ENDPOINT = "http://localhost:#{PORT}"
 
     def initialize(pid)
       @pid = pid
     end
 
     class << self
+      def endpoint(port = PORT)
+        "http://localhost:#{port}"
+      end
+
       def up(port = PORT)
         local_path = File.expand_path('../../../lib/jars/dynamodb_local',
                                       __FILE__)

--- a/lib/dynamo-local-ruby/dynamo_db_local.rb
+++ b/lib/dynamo-local-ruby/dynamo_db_local.rb
@@ -11,13 +11,13 @@ module DynamoLocalRuby
     end
 
     class << self
-      def up
+      def up(port = PORT)
         local_path = File.expand_path('../../../lib/jars/dynamodb_local',
                                       __FILE__)
         lib_path = File.join(local_path, 'DynamoDBLocal_lib')
         jar_path = File.join(local_path, 'DynamoDBLocal.jar')
         pid = spawn("java -Djava.library.path=#{lib_path} -jar #{jar_path} "\
-                    "-sharedDb -inMemory -port #{PORT}")
+                    "-sharedDb -inMemory -port #{port}")
         @instance = DynamoDBLocal.new(pid)
 
         @instance


### PR DESCRIPTION
@peakxu 

Allow the port to be changed, will allow a dynamo to be spun up for tests without mucking with a development instance.
